### PR TITLE
Update Mockito to its release version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: java


### PR DESCRIPTION
Version 'rc1' is not available in all repositories, if snapshots on remotes is not allowed/used.
