### PR TITLE
Creating API that can be invoked programatically: Use Retrolambda.reify ...

### DIFF
--- a/retrolambda/src/test/java/net/orfjackal/retrolambda/InMemoryTest.java
+++ b/retrolambda/src/test/java/net/orfjackal/retrolambda/InMemoryTest.java
@@ -1,0 +1,51 @@
+package net.orfjackal.retrolambda;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import net.orfjackal.retrolambda.files.ClassSaver;
+import net.orfjackal.retrolambda.interfaces.ClassHierarchyAnalyzer;
+import net.orfjackal.retrolambda.lambdas.LambdaClassDumper;
+import net.orfjackal.retrolambda.lambdas.LambdaClassSaver;
+import static org.junit.Assert.*;
+import org.junit.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+
+/**
+ *
+ * @author Jaroslav Tulach
+ */
+public class InMemoryTest {
+    @Test public void convertSingleClass() throws Exception {
+        InputStream is = InMemoryTest.class.getResourceAsStream("UseLambda.class");
+        byte[] arr = new byte[is.available()];
+        int len = is.read(arr);
+        assertEquals("Read just enough", arr.length, len);
+        ClassLoader classes = InMemoryTest.class.getClassLoader();
+        int bytecodeVersion = Opcodes.V1_7;
+
+        Map<String,byte[]> classFiles = Retrolambda.reify(bytecodeVersion, classes, arr);
+
+        ClassLoader l = new ClassLoader(UseLambda.class.getClassLoader().getParent()) {
+            @Override
+            protected Class<?> findClass(String name) throws ClassNotFoundException {
+                byte[] arr = classFiles.get(name.replace('.', '/'));
+                if (arr == null) {
+                    return null;
+                }
+                return defineClass(name, arr, 0, arr.length);
+            }
+        };
+
+        Class<?> useLambda = l.loadClass(UseLambda.class.getName());
+        Object ret = useLambda.getMethod("fourtyTwo").invoke(null);
+        assertEquals("Computed ok", 42, ret);
+    }
+
+}

--- a/retrolambda/src/test/java/net/orfjackal/retrolambda/UseLambda.java
+++ b/retrolambda/src/test/java/net/orfjackal/retrolambda/UseLambda.java
@@ -1,0 +1,21 @@
+package net.orfjackal.retrolambda;
+
+/**
+ *
+ * @author Jaroslav Tulach
+ */
+public final class UseLambda {
+
+    public static void invoke(int times, Runnable r) {
+        for (int i = 0; i < times; i++) {
+            r.run();
+        }
+    }
+
+    public static int fourtyTwo() {
+        int[] arr = {0};
+        invoke(21, () -> arr[0] += 2);
+        return arr[0];
+    }
+    
+}


### PR DESCRIPTION
...to remove invokeDynamic lambda based invocations from a single byte[] classfile.

I would like to embed retrolambda into my bck2brwsr ahead-of-time convertor. To do so I need to invoke it programmaticaly, not letting it write anything to disk. I am in a need of an API I could rely on to invoke such conversion. This pull request is my 1st attempt to define such API.

What do you think?