### PR TITLE
fixed two edge cases when backporting default methods

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/AddMethodDefaultImplementations.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/AddMethodDefaultImplementations.java
@@ -40,7 +40,14 @@ public class AddMethodDefaultImplementations extends ClassVisitor {
     public void visitEnd() {
         for (String anInterface : interfaces) {
             for (MethodRef interfaceMethod : methodRelocations.getInterfaceMethods(anInterface)) {
-                if (!methods.contains(interfaceMethod.withOwner(className))) {
+                boolean hasOverride = false;
+                for (MethodRef superMethod : methodRelocations.getSuperclassMethods(className)) {
+                    if (superMethod.equals(interfaceMethod.withOwner(superMethod.owner))) {
+                        hasOverride = true;
+                        break;
+                    }
+                }
+                if (!hasOverride && !methods.contains(interfaceMethod.withOwner(className))) {
                     generateDefaultImplementation(interfaceMethod);
                 }
             }

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/MethodRelocations.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/MethodRelocations.java
@@ -14,5 +14,7 @@ public interface MethodRelocations {
 
     List<MethodRef> getInterfaceMethods(String interfaceName);
 
+    List<MethodRef> getSuperclassMethods(String className);
+
     String getCompanionClass(String className);
 }


### PR DESCRIPTION
The first edge case was when a default method was overridden in a parent class and the class itself implements the interface explicitly:

Previously retrolambda would generate a delegate method in the subclass that delegates to the default implementation instead of the overridden implementation. 
Now, when checking if an implementation for a default method needs to be generated in an implementing class, it is first checked if a superclass overrides the default method. If so, no delegate method needs to be generated, as the regular invokevirtual call will find the overridden method.

The second edge case was when an interface extends two other interfaces, in which one of the superinterfaces overrides a default implementation of the other superinterface (see http://docs.oracle.com/javase/specs/jls/se8/html/jls-9.html#jls-9.4.1):

Previously retrolambda would traverse the inheritance hierarchy recursively when trying to find an implementation for a default method in a depth first search fashion, i.e. it would look for an implementation in a superinterface, then in the superinfertace of that superinterface etc..
Now it checks the superinterfaces level by level, i.e. it checks all direct superinterfaces first, then the direct superinterfaces of these interfaces etc..
This way the overridden implementation is found first.