### PR TITLE
Sytem independent path fragments in command line tool

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java
@@ -89,7 +89,7 @@ public class Retrolambda {
     }
 
     private static URL[] asUrls(String classpath) {
-        String[] paths = classpath.split(System.getProperty("path.separator"));
+        String[] paths = classpath.split("[:;]"); // Do not use System.getProperty("path.separator") for cross-platform compatibility
         return Arrays.asList(paths).stream()
                 .map(s -> Paths.get(s).toUri())
                 .map(Retrolambda::uriToUrl)


### PR DESCRIPTION
While gathering paths, use both ; and : separators to define cross-platform path fragments, instead of system-dependent  property "path.separator" (which breaks most ant scripts, especially those created by Netbeans)