### PR TITLE
Use the same FileSystem as the outputDir.

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/files/OutputDirectory.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/files/OutputDirectory.java
@@ -22,7 +22,7 @@ public class OutputDirectory {
             return;
         }
         ClassReader cr = new ClassReader(bytecode);
-        Path relativePath = Paths.get(cr.getClassName() + ".class");
+        Path relativePath = outputDir.getFileSystem().getPath(cr.getClassName() + ".class");
         writeFile(relativePath, bytecode);
     }
 


### PR DESCRIPTION
Otherwise `java.nio.file.ProviderMismatchException` can be thrown if it differs from `FileSystems.getDefault()` (which was implicitly used by `Paths.get()`).