### PR TITLE
Issue #109: Prevent child lambdas overriding parent lambdas.

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/ClassAnalyzer.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/ClassAnalyzer.java
@@ -186,6 +186,19 @@ public class ClassAnalyzer {
         return methods.values();
     }
 
+    public boolean isMethodInSuperClass(Type type, MethodSignature methodSignature) {
+        ClassInfo c = getClass(type);
+        if (c.superclass != null) {
+            Collection<MethodInfo> superClassMethods = getMethods(c.superclass);
+            for (MethodInfo superClassMethod : superClassMethods) {
+                if (superClassMethod.signature.equals(methodSignature)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     private boolean isAlreadyInherited(MethodInfo subject, Map<MethodSignature, MethodInfo> existingMethods) {
         MethodInfo existing = existingMethods.get(subject.signature);
         return existing != null && getAllInterfaces(existing.owner).contains(subject.owner);


### PR DESCRIPTION
If a child and parent class both have a lambda method of the same name,
make the child lambda private, with an accessor, so that it doesn't override the parent
lambda.
