### PR TITLE
Remove LambdaForm$Hidden annotation from emitted code

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/Transformers.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/Transformers.java
@@ -116,6 +116,7 @@ public class Transformers {
             if (targetVersion < Opcodes.V1_7) {
                 next = new SwallowSuppressedExceptions(next);
                 next = new RemoveMethodHandlesLookupReferences(next);
+                next = new RemoveLambdaHiddenReferences(next);
                 next = new RequireNonNull(next);
             }
             next = new FixInvokeStaticOnInterfaceMethod(next);

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/lambdas/RemoveLambdaHiddenReferences.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/lambdas/RemoveLambdaHiddenReferences.java
@@ -1,0 +1,31 @@
+// Copyright © 2013-2016 Esko Luontola and other Retrolambda contributors
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+
+package net.orfjackal.retrolambda.lambdas;
+
+import org.objectweb.asm.*;
+
+import static org.objectweb.asm.Opcodes.ASM5;
+
+public class RemoveLambdaHiddenReferences extends ClassVisitor {
+
+    private static final String LAMBDA_FORM_HIDDEN_NAME = "Ljava/lang/invoke/LambdaForm$Hidden;";
+
+    public RemoveLambdaHiddenReferences(ClassVisitor next) {
+        super(ASM5, next);
+    }
+
+    @Override
+    public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+        return new MethodVisitor(ASM5, super.visitMethod(access, name, desc, signature, exceptions)) {
+            @Override
+            public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+                if (LAMBDA_FORM_HIDDEN_NAME.equals(desc)) {
+                    return null;
+                }
+                return super.visitAnnotation(desc, visible);
+            }
+        };
+    }
+}


### PR DESCRIPTION
This annotation annotates some lambda methods.
It is not preserved in runtime, so it compiles fine, but create some issues for proguard.

This annotation does not exist in JDK6/7 so can be completely removed.

Related issues:
https://github.com/evant/gradle-retrolambda/issues/55
https://github.com/AntennaPod/AntennaPod/issues/1117
https://github.com/yongjhih/RxBolts/issues/3