### PR TITLE
#122 - consider module-info.class a resource

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/files/ClasspathVisitor.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/files/ClasspathVisitor.java
@@ -38,6 +38,7 @@ public abstract class ClasspathVisitor extends SimpleFileVisitor<Path> {
     protected abstract void visitResource(Path relativePath, byte[] content) throws IOException;
 
     private static boolean isJavaClass(Path file) {
-        return file.getFileName().toString().endsWith(".class");
+        String fileName = file.getFileName().toString();
+        return fileName.endsWith(".class") && !fileName.equals("module-info.class");
     }
 }


### PR DESCRIPTION
At the moment `module-info.class` does not need conversion. 
Not until Java 10, so considering it a resource should be a good strategy.