### PR TITLE
Allow processing of jars

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ Configurable system properties:
       Alternative to retrolambda.includedFiles for avoiding the command line
       length limit. The file must list one file per line with UTF-8 encoding.
 
+  retrolambda.jars
+      List of jars to process.
+      This is useful for including libraries.
+      Uses ; or : as the path separator, see java.io.File#pathSeparatorChar
+
+  retrolambda.jarsFile (alternative)
+      File listing the jars to process.
+      Alternative to retrolambda.jars for avoiding the command line
+      length limit. The file must list one file per line with UTF-8 encoding.
+
   retrolambda.quiet
       Reduces the amount of logging.
       Disabled by default. Enable by setting to "true"

--- a/end-to-end-tests/pom.xml
+++ b/end-to-end-tests/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>parent</artifactId>
-        <version>2.5.2-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 
@@ -42,7 +42,6 @@
             <scope>system</scope>
             <systemPath>${basedir}/src/test/lib/java-lang-dummies.jar</systemPath>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>net.orfjackal.retrolambda</groupId>
     <artifactId>parent</artifactId>
-    <version>2.5.2-SNAPSHOT</version>
+    <version>2.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <description>Backport of Java 8 lambda expressions to Java 7</description>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>parent</artifactId>
-        <version>2.5.2-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
         <relativePath>parent/pom.xml</relativePath>
     </parent>
 

--- a/retrolambda-maven-plugin/pom.xml
+++ b/retrolambda-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>parent</artifactId>
-        <version>2.5.2-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/retrolambda/pom.xml
+++ b/retrolambda/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>net.orfjackal.retrolambda</groupId>
         <artifactId>parent</artifactId>
-        <version>2.5.2-SNAPSHOT</version>
+        <version>2.6.0-SNAPSHOT</version>
         <relativePath>../parent/pom.xml</relativePath>
     </parent>
 

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/Config.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/Config.java
@@ -21,5 +21,7 @@ public interface Config {
 
     List<Path> getIncludedFiles();
 
+    List<Path> getJars();
+
     boolean isQuiet();
 }

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/files/OutputDirectory.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/files/OutputDirectory.java
@@ -27,7 +27,7 @@ public class OutputDirectory {
     }
 
     public void writeFile(Path relativePath, byte[] content) throws IOException {
-        Path outputFile = outputDir.resolve(relativePath);
+        Path outputFile = outputDir.resolve(relativePath.toString());
         Files.createDirectories(outputFile.getParent());
         Files.write(outputFile, content);
     }

--- a/retrolambda/src/test/java/net/orfjackal/retrolambda/RetrolambdaTest.java
+++ b/retrolambda/src/test/java/net/orfjackal/retrolambda/RetrolambdaTest.java
@@ -4,13 +4,17 @@
 
 package net.orfjackal.retrolambda;
 
+import com.google.common.collect.ImmutableMap;
 import org.junit.*;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.IOException;
+import java.io.*;
+import java.net.URI;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
+import java.util.jar.*;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -36,6 +40,8 @@ public class RetrolambdaTest {
     private Path file2;
     private Path fileInSubdir;
     private Path outsider;
+    private Path jar;
+    private Path fileInJar;
 
     @Before
     public void setup() throws IOException {
@@ -47,11 +53,15 @@ public class RetrolambdaTest {
         Files.createDirectory(subdir);
         fileInSubdir = Files.createFile(subdir.resolve("file.txt"));
         outsider = tempDir.newFile("outsider.txt").toPath();
+        jar = new File(tempDir.getRoot(), "file.jar").toPath();
+        try (FileSystem jarFileSystem = FileSystems.newFileSystem(URI.create("jar:file:" + jar.toUri().getPath()), ImmutableMap.of("create", "true"))) {
+            fileInJar = Files.createFile(jarFileSystem.getPath("/").resolve("file.txt"));
+        }
     }
 
     @Test
     public void by_default_visits_all_files_recursively() throws IOException {
-        Retrolambda.visitFiles(inputDir, null, visitor);
+        Retrolambda.visitFiles(inputDir, null, null, visitor);
 
         assertThat(visitedFiles, containsInAnyOrder(file1, file2, fileInSubdir));
     }
@@ -60,7 +70,7 @@ public class RetrolambdaTest {
     public void when_included_files_is_set_then_visits_only_those_files() throws IOException {
         List<Path> includedFiles = Arrays.asList(file1, fileInSubdir);
 
-        Retrolambda.visitFiles(inputDir, includedFiles, visitor);
+        Retrolambda.visitFiles(inputDir, includedFiles, null, visitor);
 
         assertThat(visitedFiles, containsInAnyOrder(file1, fileInSubdir));
     }
@@ -69,9 +79,19 @@ public class RetrolambdaTest {
     public void ignores_included_files_that_are_outside_the_input_directory() throws IOException {
         List<Path> includedFiles = Arrays.asList(file1, outsider);
 
-        Retrolambda.visitFiles(inputDir, includedFiles, visitor);
+        Retrolambda.visitFiles(inputDir, includedFiles, null, visitor);
 
         assertThat(visitedFiles, containsInAnyOrder(file1));
+    }
+
+    @Test
+    public void visits_files_in_jar() throws IOException {
+        List<Path> jars = Arrays.asList(jar);
+
+        Retrolambda.visitFiles(inputDir, null, jars, visitor);
+        List<URI> uris = visitedFiles.stream().map(Path::toUri).collect(Collectors.toList());
+
+        assertThat(uris, containsInAnyOrder(file1.toUri(), file2.toUri(), fileInSubdir.toUri(), fileInJar.toUri()));
     }
 
     @Test

--- a/retrolambda/src/test/java/net/orfjackal/retrolambda/SystemPropertiesConfigTest.java
+++ b/retrolambda/src/test/java/net/orfjackal/retrolambda/SystemPropertiesConfigTest.java
@@ -148,4 +148,36 @@ public class SystemPropertiesConfigTest {
         systemProperties.setProperty(SystemPropertiesConfig.INCLUDED_FILES_FILE, file.toString());
         assertThat("multiple values", config().getIncludedFiles(), is(Arrays.asList(Paths.get("one.class"), Paths.get("two.class"))));
     }
+
+    @Test
+    public void jars() throws IOException {
+        assertThat("not set", config().getJars(), is(nullValue()));
+
+        systemProperties.setProperty(SystemPropertiesConfig.JARS, "");
+        assertThat("zero values", config().getJars(), is(empty()));
+
+        systemProperties.setProperty(SystemPropertiesConfig.JARS, "/foo/one.jar");
+        assertThat("one value", config().getJars(), is(Arrays.asList(Paths.get("/foo/one.jar"))));
+
+        systemProperties.setProperty(SystemPropertiesConfig.JARS, "/foo/one.jar" + File.pathSeparator + "/foo/two.jar");
+        assertThat("multiple values", config().getJars(), is(Arrays.asList(Paths.get("/foo/one.jar"), Paths.get("/foo/two.jar"))));
+    }
+
+    @Test
+    public void jars_file() throws IOException {
+        Path file = tempDir.newFile("jars.txt").toPath();
+        assertThat("not set", config().getJars(), is(nullValue()));
+
+        Files.write(file, Arrays.asList("", "", "")); // empty lines are ignored
+        systemProperties.setProperty(SystemPropertiesConfig.JARS_FILE, file.toString());
+        assertThat("zero values", config().getJars(), is(empty()));
+
+        Files.write(file, Arrays.asList("one.jar"));
+        systemProperties.setProperty(SystemPropertiesConfig.JARS_FILE, file.toString());
+        assertThat("one value", config().getJars(), is(Arrays.asList(Paths.get("one.jar"))));
+
+        Files.write(file, Arrays.asList("one.jar", "two.jar"));
+        systemProperties.setProperty(SystemPropertiesConfig.JARS_FILE, file.toString());
+        assertThat("multiple values", config().getJars(), is(Arrays.asList(Paths.get("one.jar"), Paths.get("two.jar"))));
+    }
 }


### PR DESCRIPTION
Added new retrolambda.jars and retrolambda.jarsFile properties.
Processed jar files will be included along-side existing class files.

The goal of this is it make it easier to process libraries.