### PR TITLE
Populate default methods, when interfaces are in classpath and not in input directory

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/ClassAnalyzer.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/ClassAnalyzer.java
@@ -20,6 +20,7 @@ public class ClassAnalyzer {
     private final Map<Type, ClassInfo> classes = new HashMap<>();
     private final Map<MethodRef, MethodRef> relocatedMethods = new HashMap<>();
     private final Map<MethodRef, MethodRef> renamedLambdaMethods = new HashMap<>();
+    private final LibraryInterfaces libraryInterfaces = new LibraryInterfaces();
 
     public void analyze(byte[] bytecode) {
         analyze(new ClassReader(bytecode));
@@ -43,6 +44,7 @@ public class ClassAnalyzer {
 
             @Override
             public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                libraryInterfaces.addRequiredInterfaces(interfaces);
                 this.owner = name;
             }
 
@@ -73,6 +75,7 @@ public class ClassAnalyzer {
             public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
                 this.owner = name;
                 this.companion = name + "$";
+                libraryInterfaces.addFoundInterface(name);
             }
 
             @Override
@@ -124,6 +127,10 @@ public class ClassAnalyzer {
                 return null;
             }
         }, ClassReader.SKIP_CODE);
+    }
+
+    public LibraryInterfaces getLibraryInterfaces() {
+        return libraryInterfaces;
     }
 
     private static boolean isDefaultMethod(int access) {

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java
@@ -46,6 +46,7 @@ public class Retrolambda {
 
         ClassAnalyzer analyzer = new ClassAnalyzer();
         OutputDirectory outputDirectory = new OutputDirectory(outputDir);
+        outputDirectory.setClassNamePredicate(analyzer.getLibraryInterfaces().getIgnoreLibraryPredicate());
         Transformers transformers = new Transformers(bytecodeVersion, defaultMethodsEnabled, analyzer);
         LambdaClassSaver lambdaClassSaver = new LambdaClassSaver(outputDirectory, transformers);
 
@@ -67,6 +68,8 @@ public class Retrolambda {
                     outputDirectory.writeFile(relativePath, content);
                 }
             });
+            for(byte[] interf : analyzer.getLibraryInterfaces().getMissingInterfaces(classpath))
+                analyzer.analyze(interf);
 
             // Because Transformers.backportLambdaClass() analyzes the lambda class,
             // adding it to the analyzer's list of classes, we must take care to

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/files/OutputDirectory.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/files/OutputDirectory.java
@@ -8,10 +8,12 @@ import org.objectweb.asm.ClassReader;
 
 import java.io.IOException;
 import java.nio.file.*;
+import java.util.function.Predicate;
 
 public class OutputDirectory {
 
     private final Path outputDir;
+    private Predicate<String> classNamePredicate;
 
     public OutputDirectory(Path outputDir) {
         this.outputDir = outputDir;
@@ -22,13 +24,19 @@ public class OutputDirectory {
             return;
         }
         ClassReader cr = new ClassReader(bytecode);
-        Path relativePath = outputDir.getFileSystem().getPath(cr.getClassName() + ".class");
-        writeFile(relativePath, bytecode);
+        if (classNamePredicate == null || classNamePredicate.test(cr.getClassName())) {
+            Path relativePath = outputDir.getFileSystem().getPath(cr.getClassName() + ".class");
+            writeFile(relativePath, bytecode);
+        }
     }
 
     public void writeFile(Path relativePath, byte[] content) throws IOException {
         Path outputFile = outputDir.resolve(relativePath);
         Files.createDirectories(outputFile.getParent());
         Files.write(outputFile, content);
+    }
+
+    public void setClassNamePredicate(Predicate<String> classNamePredicate) {
+        this.classNamePredicate = classNamePredicate;
     }
 }

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/LibraryInterfaces.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/interfaces/LibraryInterfaces.java
@@ -1,0 +1,92 @@
+// Copyright © 2016 Panayotis Katsaloulis <www.panayotis.com>
+// This software is released under the Apache License 2.0.
+// The license text is at http://www.apache.org/licenses/LICENSE-2.0
+package net.orfjackal.retrolambda.interfaces;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+public class LibraryInterfaces {
+
+    private final Collection<String> requiredInterfaces = new HashSet<>();
+    private final Collection<String> inputDirInterfaces = new HashSet<>();
+    private final Collection<String> resolvedInterfaces = new HashSet<>();
+
+    public void addRequiredInterfaces(String[] interfaceNames) {
+        requiredInterfaces.addAll(Arrays.asList(interfaceNames));
+    }
+
+    public void addFoundInterface(String interfaceName) {
+        inputDirInterfaces.add(interfaceName);
+    }
+
+    public Collection<byte[]> getMissingInterfaces(List<Path> classpath) {
+        Collection<String> missingInterfaces = new HashSet<>(requiredInterfaces);
+        missingInterfaces.removeAll(inputDirInterfaces);
+        Collection<String> justFound = new HashSet<>();
+        Collection<byte[]> result = new HashSet<>();
+
+        for (Path path : classpath) {
+            if (Files.isDirectory(path))
+                for (String missingName : missingInterfaces) {
+                    Path possibleTarget = path.resolve(missingName + ".class");
+                    if (Files.isRegularFile(possibleTarget))
+                        try {
+                            result.add(Files.readAllBytes(possibleTarget));
+                            justFound.add(missingName);
+                        } catch (IOException ex) {
+                        }
+                }
+            else if (Files.isRegularFile(path) && path.getFileName().toString().toLowerCase().endsWith(".jar")) {
+                JarFile jar = null;
+                try {
+                    jar = new JarFile(path.toFile());
+                } catch (IOException ex) {
+                }
+                if (jar != null)
+                    for (String missingName : missingInterfaces) {
+                        JarEntry entry = jar.getJarEntry(missingName + ".class");
+                        if (entry != null)
+                            try (InputStream inputStream = jar.getInputStream(entry)) {
+                                byte[] bytes = getBytes(inputStream);
+                                if (bytes != null)
+                                    result.add(bytes);
+                                justFound.add(missingName);
+                            } catch (IOException ex) {
+                            }
+                    }
+            }
+            missingInterfaces.removeAll(justFound);
+            resolvedInterfaces.addAll(justFound);
+            justFound.clear();
+        }
+        return result;
+    }
+
+    public Predicate<String> getIgnoreLibraryPredicate() {
+        return className -> !resolvedInterfaces.contains(className);
+    }
+
+    private byte[] getBytes(InputStream in) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(100);
+        int value;
+        try {
+            while ((value = in.read()) >= 0)
+                out.write(value);
+        } catch (IOException ex) {
+            return null;
+        }
+        return out.toByteArray();
+    }
+
+}


### PR DESCRIPTION
Updated patch to be in sync with current retrolambda changes