### PR TITLE
Swallow "addSuppressed" for all Exceptions and Errors

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/trywithresources/SwallowSuppressedExceptions.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/trywithresources/SwallowSuppressedExceptions.java
@@ -21,9 +21,11 @@ public class SwallowSuppressedExceptions extends ClassVisitor {
             @Override
             public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
                 if (opcode == Opcodes.INVOKEVIRTUAL
-                        && owner.equals("java/lang/Throwable")
                         && name.equals("addSuppressed")
-                        && desc.equals("(Ljava/lang/Throwable;)V")) {
+                        && desc.equals("(Ljava/lang/Throwable;)V")
+                        && (owner.equals("java/lang/Throwable")
+                                || owner.endsWith("Exception")
+                                || owner.endsWith("Error"))) {
                     super.visitInsn(Opcodes.POP); // the suppressed exception
                     super.visitInsn(Opcodes.POP); // the original exception
                 } else {


### PR DESCRIPTION
Previously, we would only swallow "addSuppressed" (for Java 6 or older) if the owner was "java/lang/Throwable". However, addSuppressed may have been overriden by other exceptions.

Catch all methods named "addSupressed" that are defined either in java/lang/Throwable or any owner ending in "Exception" or "Error".