### PR TITLE
Handle Objects.requireNonNull (Object, String)

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/requirenonnull/RequireNonNull.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/requirenonnull/RequireNonNull.java
@@ -39,7 +39,8 @@ public class RequireNonNull extends ClassVisitor {
                 if (opcode == Opcodes.INVOKESTATIC
                         && owner.equals("java/util/Objects")
                         && name.equals("requireNonNull")
-                        && desc.equals("(Ljava/lang/Object;)Ljava/lang/Object;")) {
+                        && (desc.equals("(Ljava/lang/Object;)Ljava/lang/Object;")
+                                || desc.equals("(Ljava/lang/Object;Ljava/lang/String;)Ljava/lang/Object;"))) {
                     super.visitInsn(Opcodes.DUP);
                     super.visitMethodInsn(
                             Opcodes.INVOKEVIRTUAL,


### PR DESCRIPTION
Previously, for target 1.6 and older, we were only replacing Objects.requireNonNull(Object) with Object.getClass, not Objects.requireNonNull(Object,String).

Map both to Object.getClass, which seems to work.