### PR TITLE
Require Java 1.8 to build, bump maven-plugin-plugin version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -318,7 +318,7 @@
 
                 <plugin>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.4</version>
+                    <version>3.9.0</version>
                 </plugin>
 
                 <plugin>

--- a/retrolambda-api/pom.xml
+++ b/retrolambda-api/pom.xml
@@ -21,7 +21,7 @@
                 <configuration>
                     <toolchains>
                         <jdk>
-                            <version>1.6</version>
+                            <version>1.8</version>
                         </jdk>
                     </toolchains>
                 </configuration>
@@ -30,8 +30,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 

--- a/retrolambda-maven-plugin/pom.xml
+++ b/retrolambda-maven-plugin/pom.xml
@@ -73,7 +73,7 @@
                 <configuration>
                     <toolchains>
                         <jdk>
-                            <version>1.6</version>
+                            <version>1.8</version>
                         </jdk>
                     </toolchains>
                 </configuration>
@@ -82,8 +82,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
Previously, we required Java 1.6 to compile (a corresponding entry had to be made in ~/.m2/toolchains.xml), however the code already required try-with-resources (HelpMojo).

Bump source code compatibility to Java 1.8, and remove the JDK 1.6 requirement from Maven POM files.

Also update the maven-plugin-plugin version, which seems to fix a related problem when running with newer Maven environments.