### PR TITLE
Add Eclipse annotations to prevent error upon m2e project import

### DIFF
--- a/retrolambda/pom.xml
+++ b/retrolambda/pom.xml
@@ -41,6 +41,13 @@
             <artifactId>minlog</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.annotation</artifactId>
+            <version>2.2.700</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
The Eclipse compiler would complain about the missing annotations if annotation-based null analysis was enabled by default.

Adding the dependency with scope=provided to satisfy Eclipse's demands without making it a true dependency of the project.