### PR TITLE
Do not try to translate classes in META-INF/versions

### DIFF
--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java
@@ -103,9 +103,7 @@ public class Retrolambda {
     }
 
     static void visitFiles(Path inputDir, List<Path> includedFiles, FileVisitor<Path> visitor) throws IOException {
-        if (includedFiles != null) {
-            visitor = new FilteringFileVisitor(includedFiles, visitor);
-        }
+        visitor = new FilteringFileVisitor(includedFiles, visitor);
         Files.walkFileTree(inputDir, visitor);
     }
 

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/files/FilteringFileVisitor.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/files/FilteringFileVisitor.java
@@ -15,7 +15,7 @@ public class FilteringFileVisitor implements FileVisitor<Path> {
     private final FileVisitor<? super Path> target;
 
     public FilteringFileVisitor(Collection<Path> fileFilter, FileVisitor<Path> target) {
-        this.fileFilter = new HashSet<>(fileFilter);
+        this.fileFilter = fileFilter == null ? null : new HashSet<>(fileFilter);
         this.target = target;
     }
 
@@ -26,12 +26,15 @@ public class FilteringFileVisitor implements FileVisitor<Path> {
 
     @Override
     public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+        if (dir.toString().endsWith("/META-INF/versions")) {
+            return FileVisitResult.SKIP_SUBTREE;
+        }
         return target.preVisitDirectory(dir, attrs);
     }
 
     @Override
     public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-        if (fileFilter.contains(file)) {
+        if (fileFilter == null || fileFilter.contains(file)) {
             return target.visitFile(file, attrs);
         } else {
             return FileVisitResult.CONTINUE;


### PR DESCRIPTION
In a multirelease-jar environment, there could be classes under META-INF/versions, which retrolambda would try to translate.

As per definition, these are Java classes newer than Java 1.8, so they shouldn't be processed at all, especially since it is expected that there is at least some version (hopefully 1.8 or older) of that class in the path that is not prefixed by META-INF/versions.

Extend FilteringFileVisitor to never visit /META-INF/versions, and modify FilteringFileVisitor so it's usable in all cases, even when no other filtering is required.