### PR TITLE
Add "fixJava8Classpath" option to support multirelease projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ Configurable system properties:
       Alternative to retrolambda.classpath for avoiding the command line
       length limit. The file must list one file per line with UTF-8 encoding.
 
+  retrolambda.fixJava8Classpath
+      Whether to replace occurrences of classpath entries ending in /classes
+      with entries ending in /classes-java8 if such directory is available.
+      Disabled by default. Enable by setting to "true"
+
   retrolambda.includedFiles
       List of files to process, instead of processing all files.
       This is useful for a build tool to support incremental compilation.

--- a/retrolambda-api/src/main/java/net/orfjackal/retrolambda/api/RetrolambdaApi.java
+++ b/retrolambda-api/src/main/java/net/orfjackal/retrolambda/api/RetrolambdaApi.java
@@ -17,4 +17,5 @@ public class RetrolambdaApi {
     public static final String DEFAULT_METHODS = PREFIX + "defaultMethods";
     public static final String BYTECODE_VERSION = PREFIX + "bytecodeVersion";
     public static final String JAVAC_HACKS = PREFIX + "javacHacks";
+    public static final String FIX_JAVA8_CLASSPATH = PREFIX + "fixJava8Classpath";
 }

--- a/retrolambda-maven-plugin/src/main/java/net/orfjackal/retrolambda/maven/ProcessClassesMojo.java
+++ b/retrolambda-maven-plugin/src/main/java/net/orfjackal/retrolambda/maven/ProcessClassesMojo.java
@@ -107,6 +107,14 @@ abstract class ProcessClassesMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     public boolean fork;
 
+    /**
+     * Whether to replace occurrences of classpath entries ending in {@code /classes}
+     * with entries ending in {@code /classes-java8} if such directory is available.
+     * @since 2.5.8
+     */
+    @Parameter(defaultValue = "false", property = "fixJava8Classpath", required = false)
+    public boolean fixJava8Classpath;
+
     protected abstract File getInputDir();
 
     protected abstract File getOutputDir();
@@ -126,6 +134,7 @@ abstract class ProcessClassesMojo extends AbstractMojo {
         config.setProperty(RetrolambdaApi.OUTPUT_DIR, getOutputDir().getAbsolutePath());
         config.setProperty(RetrolambdaApi.CLASSPATH, getClasspath());
         config.setProperty(RetrolambdaApi.JAVAC_HACKS, "" + javacHacks);
+        config.setProperty(RetrolambdaApi.FIX_JAVA8_CLASSPATH, "" + fixJava8Classpath);
 
         if (fork) {
             processClassesInForkedProcess(config);

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/Config.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/Config.java
@@ -24,4 +24,6 @@ public interface Config {
     boolean isJavacHacksEnabled();
 
     boolean isQuiet();
+
+    boolean isFixJava8Classpath();
 }

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/Retrolambda.java
@@ -38,6 +38,21 @@ public class Retrolambda {
         } else {
             Log.INFO();
         }
+
+        if (config.isFixJava8Classpath()) {
+          List<Path> classpathNew = new ArrayList<>();
+          for(Path p : classpath) {
+            if (p.toString().endsWith("/classes") && Files.isDirectory(p)) {
+              Path p2 = p.getParent().resolve("classes-java8");
+              if (Files.isDirectory(p2)) {
+                p = p2;
+              }
+            }
+            classpathNew.add(p);
+          }
+          classpath = classpathNew;
+        }
+
         Log.info("Bytecode version: " + bytecodeVersion + " (" + Bytecode.getJavaVersion(bytecodeVersion) + ")");
         Log.info("Default methods:  " + defaultMethodsEnabled);
         Log.info("Input directory:  " + inputDir);
@@ -47,6 +62,7 @@ public class Retrolambda {
         Log.info("JVM version:      " + System.getProperty("java.version"));
         Log.info("Agent enabled:    " + Agent.isEnabled());
         Log.info("javac hacks:      " + isJavacHacksEnabled);
+        Log.info("Fix classpath:    " + config.isFixJava8Classpath());
 
         if (!Files.isDirectory(inputDir)) {
             Log.info("Nothing to do; not a directory: " + inputDir);

--- a/retrolambda/src/main/java/net/orfjackal/retrolambda/SystemPropertiesConfig.java
+++ b/retrolambda/src/main/java/net/orfjackal/retrolambda/SystemPropertiesConfig.java
@@ -132,6 +132,20 @@ public class SystemPropertiesConfig implements Config {
                 "length limit. The file must list one file per line with UTF-8 encoding.");
     }
 
+
+    // fix Java 8 classpath
+
+    static {
+        optionalParameterHelp(FIX_JAVA8_CLASSPATH,
+                "Whether to replace occurrences of classpath entries ending in /classes",
+                "with entries ending in /classes-java8 if such directory is available.",
+                "Disabled by default. Enable by setting to \"true\"");
+    }
+
+    @Override
+    public boolean isFixJava8Classpath() {
+        return Boolean.parseBoolean(p.getProperty(FIX_JAVA8_CLASSPATH, "false"));
+    }
     @Override
     public List<Path> getClasspath() {
         String classpath = p.getProperty(CLASSPATH);


### PR DESCRIPTION
In certain environments that build multirelease jars, the Maven "classes" directory contains class files with newer Java versions, whereas the Java 8 versions are stored elsewhere.

Add a boolean "fixJava8Classpath" option that, once enabled, automatically fixes these classpath entries. It checks for the presence of a sibling directory named "classes-java8". If that's available, then the original classpath entry is replaced.