### PR TITLE
plugin: Try to get "jdk 1.8" from toolchains.xml, bump Maven to >= 3.3.9

### DIFF
--- a/retrolambda-maven-plugin/pom.xml
+++ b/retrolambda-maven-plugin/pom.xml
@@ -13,7 +13,7 @@
     <packaging>maven-plugin</packaging>
 
     <prerequisites>
-        <maven>3.0</maven>
+        <maven>3.3.9</maven>
     </prerequisites>
 
     <dependencies>
@@ -31,8 +31,15 @@
 
         <dependency>
             <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.3.9</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
-            <version>3.0</version>
+            <version>3.3.9</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -50,7 +57,7 @@
         <dependency>
             <groupId>org.twdata.maven</groupId>
             <artifactId>mojo-executor</artifactId>
-            <version>2.2.0</version>
+            <version>2.4.1-m2</version>
         </dependency>
 
         <dependency>
@@ -70,6 +77,7 @@
 
             <plugin>
                 <artifactId>maven-toolchains-plugin</artifactId>
+                <version>3.1.0</version>
                 <configuration>
                     <toolchains>
                         <jdk>

--- a/retrolambda-maven-plugin/src/main/java/net/orfjackal/retrolambda/maven/ProcessClassesMojo.java
+++ b/retrolambda-maven-plugin/src/main/java/net/orfjackal/retrolambda/maven/ProcessClassesMojo.java
@@ -222,21 +222,37 @@ abstract class ProcessClassesMojo extends AbstractMojo {
     }
 
     String getJavaCommand() {
-        String javaCommand = getJavaCommand(new File(System.getProperty("java.home")));
+      String javaCommand = null;
 
-        Toolchain tc = toolchainManager.getToolchainFromBuildContext("jdk", session);
-        if (tc != null) {
-            getLog().info("Toolchain in retrolambda-maven-plugin: " + tc);
-            javaCommand = tc.findTool("java");
-        }
+      List<Toolchain> tcCandidates = toolchainManager.getToolchains(session, "jdk", Collections
+          .singletonMap("version", "1.8"));
+      for (Toolchain tc : tcCandidates) {
+          String cmd = tc.findTool("java");
+          if (cmd != null) {
+              getLog().info("Toolchain in retrolambda-maven-plugin: " + tc);
+              javaCommand = cmd;
+              break;
+          }
+      }
 
-        if (java8home != null) {
-            if (tc != null) {
-                getLog().warn("Toolchains are ignored, 'java8home' parameter is set to " + java8home);
-            }
-            javaCommand = getJavaCommand(java8home);
-        }
-        return javaCommand;
+      Toolchain tc = toolchainManager.getToolchainFromBuildContext("jdk", session);
+      if (javaCommand == null && tc != null) {
+          getLog().info("Toolchain in retrolambda-maven-plugin: " + tc);
+          javaCommand = tc.findTool("java");
+      }
+
+      if (java8home != null) {
+          if (tc != null) {
+              getLog().warn("Toolchains are ignored, 'java8home' parameter is set to " + java8home);
+          }
+          javaCommand = getJavaCommand(java8home);
+      }
+
+      if (javaCommand == null) {
+          javaCommand = getJavaCommand(new File(System.getProperty("java.home")));
+      }
+
+      return javaCommand;
     }
 
     private static String getJavaCommand(File javaHome) {

--- a/retrolambda-maven-plugin/src/main/java/net/orfjackal/retrolambda/maven/ProcessTestClassesMojo.java
+++ b/retrolambda-maven-plugin/src/main/java/net/orfjackal/retrolambda/maven/ProcessTestClassesMojo.java
@@ -4,11 +4,14 @@
 
 package net.orfjackal.retrolambda.maven;
 
-import org.apache.maven.artifact.DependencyResolutionRequiredException;
-import org.apache.maven.plugins.annotations.*;
-
 import java.io.File;
 import java.util.List;
+
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
  * Processes test classes compiled with Java 8 so that they will be compatible with

--- a/retrolambda-maven-plugin/src/test/java/net/orfjackal/retrolambda/maven/ProcessClassesMojoTest.java
+++ b/retrolambda-maven-plugin/src/test/java/net/orfjackal/retrolambda/maven/ProcessClassesMojoTest.java
@@ -76,8 +76,19 @@ public class ProcessClassesMojoTest {
             return toolChainsByType.get(type);
         }
 
-        public void setJdkToolChain(JavaToolChain toolChain) {
+        public void setJdkToolChain(JavaToolchain toolChain) {
             toolChainsByType.put("jdk", toolChain);
+        }
+
+        @Override
+        public List<Toolchain> getToolchains(MavenSession session, String type,
+            Map<String, String> requirements) {
+          Toolchain tc = toolChainsByType.get("jdk");
+          if(tc == null) {
+            return Collections.emptyList();
+          } else {
+            return Collections.singletonList(tc);
+          }
         }
     }
 


### PR DESCRIPTION
Previously, we were OK getting any JDK version from the build context.

This breaks the Maven plugin when executing with a too new Java version (e.g., 20).

Filter through the toolchains available in toolchains.xml, and use the first working one that is marked "jdk 1.8".

This change requires updating the Maven Plugin API requirement.